### PR TITLE
Fix deprecated notice about client_shutdown

### DIFF
--- a/actix-web/src/server.rs
+++ b/actix-web/src/server.rs
@@ -226,7 +226,7 @@ where
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "4.0.0", note = "Renamed to `client_request_timeout`.")]
+    #[deprecated(since = "4.0.0", note = "Renamed to `client_disconnect_timeout`.")]
     pub fn client_shutdown(self, dur: u64) -> Self {
         self.client_disconnect_timeout(Duration::from_millis(dur))
     }


### PR DESCRIPTION
## PR Type
Other


## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt.
- [ ] (Team) Label with affected crates and semver status.


## Overview
I wanted to fix the deprecation notice for the `client_shutdown` method, that seems to have a copy-paste typo.
